### PR TITLE
Fix opencv3

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -92,10 +92,10 @@ void test()
 	RNG random;
 	Mat color_img = imread("opencvblobslibBIG.png");
 	//resize(color_img,color_img,Size(IMSIZE,IMSIZE),0,0,INTER_LINEAR);
-	namedWindow("Color Image",CV_WINDOW_NORMAL);
-	namedWindow("Gray Image",CV_WINDOW_NORMAL);
-	namedWindow("Binary Image",CV_WINDOW_NORMAL);
-	namedWindow("Blobs Image",CV_WINDOW_NORMAL);
+	namedWindow("Color Image", WINDOW_NORMAL);
+	namedWindow("Gray Image", WINDOW_NORMAL);
+	namedWindow("Binary Image", WINDOW_NORMAL);
+	namedWindow("Blobs Image", WINDOW_NORMAL);
 	imshow("Color Image",color_img);
 	Mat binary_img(color_img.size(),CV_8UC1);
 	cvtColor(color_img,binary_img,CV_BGR2GRAY);
@@ -294,8 +294,8 @@ void testJoin(){
 void testRandomImage()
 {
 	cout << "Random test: Press esc to quit"<<endl;
-	namedWindow("Binary Image",CV_WINDOW_NORMAL);
-	namedWindow("Blobs Image",CV_WINDOW_NORMAL);
+	namedWindow("Binary Image", WINDOW_NORMAL);
+	namedWindow("Blobs Image", WINDOW_NORMAL);
 	Mat image(256,256,CV_8UC1),nulMask;
 	Mat out(image.size(),CV_8UC3);
 	RNG rand(0);

--- a/library/BlobResult.cpp
+++ b/library/BlobResult.cpp
@@ -85,12 +85,12 @@ CBlobResult::CBlobResult(IplImage *source, IplImage *mask,int numThreads)
 {
 	if(mask!=NULL){
 		Mat temp = Mat::zeros(Size(source->width,source->height),CV_8UC1);
-		Mat(source).copyTo(temp,Mat(mask));
+		cvarrToMat(source).copyTo(temp, cvarrToMat(mask));
 		compLabeler.set(numThreads,temp);
 		compLabeler.doLabeling(m_blobs);
 	}
 	else{
-		compLabeler.set(numThreads,source);
+		compLabeler.set(numThreads, cvarrToMat(source));
 		compLabeler.doLabeling(m_blobs);
 	}
 }

--- a/library/BlobResultShared.cpp
+++ b/library/BlobResultShared.cpp
@@ -29,7 +29,8 @@ CBlobResultShared::CBlobResultShared()
 
 CBlobResultShared::CBlobResultShared(IplImage *source, IplImage *mask,int numThreads)
 {
-    Mat s(source),m(mask);
+	Mat s = cvarrToMat(source);
+	Mat m = cvarrToMat(mask);
     detect(s,m,numThreads);
 //    Blob_vector temp;
 //	if(mask!=NULL){

--- a/library/blob.cpp
+++ b/library/blob.cpp
@@ -479,7 +479,7 @@ double CBlob::Mean( IplImage *image )
 	offset.x = -m_boundingBox.x;
 	offset.y = -m_boundingBox.y;
 
-  Mat mask_mat(mask);
+	Mat mask_mat = cv::cvarrToMat(mask);  //Mat mask_mat(mask);
       
 	//If joined
 	if(isJoined){
@@ -789,9 +789,9 @@ CvBox2D CBlob::GetEllipse()
 void CBlob::FillBlob( IplImage *image, CvScalar color, int offsetX , int offsetY, bool intContours, const IplImage *srcImage) 					  
 {
 	if(srcImage==NULL)
-		FillBlob(Mat(image),color,offsetX,offsetY,intContours,Mat());
+		FillBlob(cvarrToMat(image), color, offsetX, offsetY, intContours, Mat());
 	else
-		FillBlob(Mat(image),color,offsetX,offsetY,intContours,Mat(srcImage));
+		FillBlob(cvarrToMat(image), color, offsetX, offsetY, intContours, cvarrToMat(srcImage));
 }
 void CBlob::FillBlob( Mat image, CvScalar color, int offsetX, int offsetY, bool intContours, const Mat srcImage){
 	CV_FUNCNAME("CBlob::FillBlob");


### PR DESCRIPTION
I am still using your library after upgrading to OpenCV 3.0. This pull request change the library based on OpenCV 3.0 by correctly converting IplImage to Mat. 
In the example part, I change CV_WINDOW_NORMAL to WINDOW_NORMAL

Resolve #16.