### PR TITLE
Require nThreads to be a sane value

### DIFF
--- a/library/ComponentLabeling.cpp
+++ b/library/ComponentLabeling.cpp
@@ -454,6 +454,9 @@ myCompLabelerGroup::~myCompLabelerGroup()
 
 void myCompLabelerGroup::set( int nThreads, Mat binIm )
 {
+  if (nThreads <= 0) {
+    nThreads = 1;
+  }
 	this->numThreads=nThreads;
 	if(binIm.isContinuous()){
 		this->img=binIm;

--- a/library/ComponentLabeling.cpp
+++ b/library/ComponentLabeling.cpp
@@ -454,9 +454,7 @@ myCompLabelerGroup::~myCompLabelerGroup()
 
 void myCompLabelerGroup::set( int nThreads, Mat binIm )
 {
-  if (nThreads <= 0) {
-    nThreads = 1;
-  }
+  CV_Assert(nThreads > 0);
 	this->numThreads=nThreads;
 	if(binIm.isContinuous()){
 		this->img=binIm;

--- a/library/ComponentLabeling.cpp
+++ b/library/ComponentLabeling.cpp
@@ -454,7 +454,7 @@ myCompLabelerGroup::~myCompLabelerGroup()
 
 void myCompLabelerGroup::set( int nThreads, Mat binIm )
 {
-  CV_Assert(nThreads > 0);
+	CV_Assert(nThreads > 0);
 	this->numThreads=nThreads;
 	if(binIm.isContinuous()){
 		this->img=binIm;


### PR DESCRIPTION
This causes all kinds of interesting undefined behavior if nThreads is zero here
